### PR TITLE
Fix php-activerecord version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require": {
         "php": ">=5.3.0",
         "silex/silex": "~1.0",
-        "php-activerecord/php-activerecord": "~1.1.1"
+        "php-activerecord/php-activerecord": "~1.1"
     },
     "autoload": {
         "psr-0": { "Ruckuus\\Silex": "src" }


### PR DESCRIPTION
There is already version 1.2 with updates for PHP7, but currently used version restriction prevents composer updating to it.